### PR TITLE
Create webzfs-install.yml

### DIFF
--- a/webzfs-install.yml
+++ b/webzfs-install.yml
@@ -10,7 +10,7 @@
         - libsodium
         - git-lite
       Debian:
-        - pyhon3.11
+        - python3.11
         - nodejs
         - libsodium23
         - git
@@ -45,7 +45,7 @@
         state: stopped
 
     - name: Run installer script
-      shell: "yes | /var/tmp/webzfs/install_{{ ansible_os_family|lower }}.sh"
+      shell: "yes | /var/tmp/webzfs/install_{{ ansible_system|lower }}.sh"
 
     - name: Start/restart webzfs service
       service:


### PR DESCRIPTION
Ansible playbook to install webzfs. Designed to work on FreeBSD and linux. Performs the following tasks:

* Installs prerequisites
* Clones the repo
* Sets proper permissions
* Runs installer script. Answers yes to prompts for whether to set up as service and whether to start now.