### PR TITLE
feat: add Bun support to scripts and SCSI/SAS SMART

### DIFF
--- a/install_freebsd.sh
+++ b/install_freebsd.sh
@@ -202,12 +202,16 @@ echo
 # python311 - Python runtime (bundles pip via ensurepip, so a separate
 #             py311-pip package is not required and is not built for the
 #             default Python flavor on FreeBSD 15.x)
-# node/npm - Node.js for building CSS assets
+# node/npm - installed when Bun is unavailable for building CSS assets
 # smartmontools - SMART disk monitoring
 # sanoid - ZFS snapshot management (includes syncoid for replication)
 # libsodium - runtime dependency of pynacl (used by paramiko for SSH)
 # Note: rust, gmake are NOT needed when using pre-compiled wheels
-pkg install -y python311 node npm smartmontools sanoid libsodium
+if command_exists bun; then
+    pkg install -y python311 smartmontools sanoid libsodium
+else
+    pkg install -y python311 node npm smartmontools sanoid libsodium
+fi
 
 if [ $? -ne 0 ]; then
     printf "${RED}Error: Failed to install required packages${NC}\n"
@@ -241,19 +245,24 @@ fi
 
 printf "${GREEN}✓${NC} Python $PYTHON_VERSION found ($PYTHON_CMD)\n"
 
-if ! command_exists node; then
-    printf "${RED}Error: Node.js was not installed correctly${NC}\n"
+if command_exists bun; then
+    JS_PACKAGE_MANAGER="bun"
+    JS_PACKAGE_MANAGER_PATH="$(command -v bun)"
+    JS_PACKAGE_MANAGER_NAME="Bun"
+    printf "${GREEN}✓${NC} Bun $(bun --version) found\n"
+elif ! command_exists node; then
+    printf "${RED}Error: Neither Bun nor Node.js was installed correctly${NC}\n"
     exit 1
-fi
-
-printf "${GREEN}✓${NC} Node.js $(node --version) found\n"
-
-if ! command_exists npm; then
+elif ! command_exists npm; then
     printf "${RED}Error: npm was not installed correctly${NC}\n"
     exit 1
+else
+    printf "${GREEN}✓${NC} Node.js $(node --version) found\n"
+    JS_PACKAGE_MANAGER="npm"
+    JS_PACKAGE_MANAGER_PATH="$(command -v npm)"
+    JS_PACKAGE_MANAGER_NAME="Node.js"
+    printf "${GREEN}✓${NC} npm $(npm --version) found\n"
 fi
-
-printf "${GREEN}✓${NC} npm $(npm --version) found\n"
 
 # Check for ZFS (should be built-in on FreeBSD)
 if ! command_exists zpool || ! command_exists zfs; then
@@ -356,7 +365,7 @@ printf "${GREEN}✓${NC} Data directory and files created\n"
 echo
 
 # Install dependencies
-echo "Installing Python and Node.js dependencies..."
+echo "Installing Python and ${JS_PACKAGE_MANAGER_NAME} dependencies..."
 echo "(This should be quick with pre-compiled wheels...)"
 echo
 
@@ -416,14 +425,18 @@ if ! .venv/bin/pip install --find-links="$WHEELS_DIR" -r requirements.txt >> ins
     exit 1
 fi
 
-echo "Installing Node.js dependencies..."
-npm install >> install_log.txt 2>&1
+echo "Installing ${JS_PACKAGE_MANAGER_NAME} dependencies..."
+"$JS_PACKAGE_MANAGER_PATH" install >> install_log.txt 2>&1
 
 echo "Creating static directory structure..."
 mkdir -p static/css
 
 echo "Building static assets..."
-npm run build:css >> install_log.txt 2>&1
+if [ "$JS_PACKAGE_MANAGER" = "bun" ]; then
+    "$JS_PACKAGE_MANAGER_PATH" ./node_modules/postcss-cli/index.js src/styles.css -o static/css/styles.css >> install_log.txt 2>&1
+else
+    "$JS_PACKAGE_MANAGER_PATH" run build:css >> install_log.txt 2>&1
+fi
 
 # Create .env file if it doesn't exist
 if [ ! -f ".env" ]; then
@@ -437,7 +450,7 @@ fi
 
 echo
 printf "${GREEN}✓${NC} Python dependencies installed\n"
-printf "${GREEN}✓${NC} Node.js dependencies installed\n"
+printf "${GREEN}✓${NC} ${JS_PACKAGE_MANAGER_NAME} dependencies installed\n"
 printf "${GREEN}✓${NC} Static assets built\n"
 printf "${GREEN}✓${NC} Configuration file created\n"
 echo

--- a/install_linux.sh
+++ b/install_linux.sh
@@ -84,20 +84,32 @@ fi
 
 echo -e "${GREEN}✓${NC} Python $PYTHON_VERSION found ($PYTHON_CMD)"
 
-if ! command_exists node; then
-    echo -e "${RED}Error: Node.js is not installed${NC}"
-    echo "Please install Node.js v20+ and try again"
+if ! "$PYTHON_PATH" -m ensurepip --version >/dev/null 2>&1; then
+    echo -e "${RED}Error: Python virtual environment support is not installed${NC}"
+    echo "Please install ${PYTHON_CMD}-venv and try again"
     exit 1
 fi
 
-echo -e "${GREEN}✓${NC} Node.js $(node --version) found"
-
-if ! command_exists npm; then
+if command_exists bun; then
+    JS_PACKAGE_MANAGER="bun"
+    JS_PACKAGE_MANAGER_PATH="$(command -v bun)"
+    JS_PACKAGE_MANAGER_NAME="Bun"
+    echo -e "${GREEN}✓${NC} Bun $(bun --version) found"
+elif ! command_exists node; then
+    echo -e "${RED}Error: Neither Bun nor Node.js is installed${NC}"
+    echo "Please install Bun or Node.js v20+ with npm and try again"
+    exit 1
+elif ! command_exists npm; then
     echo -e "${RED}Error: npm is not installed${NC}"
+    echo "Please install npm or Bun and try again"
     exit 1
+else
+    echo -e "${GREEN}✓${NC} Node.js $(node --version) found"
+    JS_PACKAGE_MANAGER="npm"
+    JS_PACKAGE_MANAGER_PATH="$(command -v npm)"
+    JS_PACKAGE_MANAGER_NAME="npm"
+    echo -e "${GREEN}✓${NC} npm $(npm --version) found"
 fi
-
-echo -e "${GREEN}✓${NC} npm $(npm --version) found"
 
 # Check for sudo
 # WebZFS runs as the unprivileged webzfs user and requires sudo to execute
@@ -190,6 +202,13 @@ if [ ! -d "$INSTALL_DIR" ]; then
     mkdir -p "$INSTALL_DIR"
 fi
 
+if [ "$JS_PACKAGE_MANAGER" = "bun" ]; then
+    BUN_DEPLOY_PATH="${INSTALL_DIR}/.bun/bin/bun"
+    mkdir -p "$(dirname "$BUN_DEPLOY_PATH")"
+    install -m 0755 "$JS_PACKAGE_MANAGER_PATH" "$BUN_DEPLOY_PATH"
+    JS_PACKAGE_MANAGER_PATH="$BUN_DEPLOY_PATH"
+fi
+
 # Copy application files to installation directory
 echo "Copying application files from $SOURCE_DIR to $INSTALL_DIR..."
 rsync -a --exclude='.venv' --exclude='node_modules' --exclude='.git' --exclude='*.log' \
@@ -236,7 +255,7 @@ echo
 # Create a temporary install script that runs as the webzfs user
 # Using a script file instead of heredoc to preserve stdin for later read prompts
 TEMP_INSTALL_SCRIPT="${INSTALL_DIR}/_install_deps.sh"
-echo "Installing Python and Node.js dependencies as $WEBZFS_USER..."
+echo "Installing Python and ${JS_PACKAGE_MANAGER_NAME} dependencies as $WEBZFS_USER..."
 echo "(This may take a few minutes...)"
 echo
 
@@ -252,8 +271,16 @@ cd /opt/webzfs
 
 # Use the full Python path
 PYTHON_PATH="$PYTHON_PATH"
+JS_PACKAGE_MANAGER="$JS_PACKAGE_MANAGER_PATH"
+JS_PACKAGE_MANAGER_TYPE="$JS_PACKAGE_MANAGER"
+JS_PACKAGE_MANAGER_NAME="$JS_PACKAGE_MANAGER_NAME"
 
 # Create virtual environment
+if [ -d ".venv" ] && [ ! -x ".venv/bin/pip" ]; then
+    echo "Virtual environment is missing pip, recreating..."
+    rm -rf .venv
+fi
+
 if [ -d ".venv" ]; then
     echo "Virtual environment already exists"
 else
@@ -267,14 +294,18 @@ echo "Installing/upgrading pip in virtual environment..."
 echo "Installing Python dependencies in virtual environment..."
 .venv/bin/pip install -r requirements.txt >> install_log.txt 2>&1
 
-echo "Installing Node.js dependencies..."
-npm install >> install_log.txt 2>&1
+echo "Installing \$JS_PACKAGE_MANAGER_NAME dependencies..."
+"\$JS_PACKAGE_MANAGER" install >> install_log.txt 2>&1
 
 echo "Creating static directory structure..."
 mkdir -p static/css
 
 echo "Building static assets..."
-npm run build:css >> install_log.txt 2>&1
+if [ "\$JS_PACKAGE_MANAGER_TYPE" = "bun" ]; then
+    "\$JS_PACKAGE_MANAGER" ./node_modules/postcss-cli/index.js src/styles.css -o static/css/styles.css >> install_log.txt 2>&1
+else
+    "\$JS_PACKAGE_MANAGER" run build:css >> install_log.txt 2>&1
+fi
 
 # Create .env file if it doesn't exist
 if [ ! -f ".env" ]; then
@@ -305,7 +336,7 @@ rm -f "$TEMP_INSTALL_SCRIPT"
 
 echo
 echo -e "${GREEN}✓${NC} Python dependencies installed"
-echo -e "${GREEN}✓${NC} Node.js dependencies installed"
+echo -e "${GREEN}✓${NC} ${JS_PACKAGE_MANAGER_NAME} dependencies installed"
 echo -e "${GREEN}✓${NC} Static assets built"
 echo -e "${GREEN}✓${NC} Configuration file created"
 echo

--- a/install_netbsd.sh
+++ b/install_netbsd.sh
@@ -113,10 +113,17 @@ install_dependencies() {
 
     # Install System Packages
     echo "Installing system packages via pkgin..."
-    pkgin -y install python311 py311-pip nodejs smartmontools \
-                     git perl mbuffer lzop pv mozilla-rootcerts \
-                     p5-Config-IniFiles p5-Capture-Tiny \
-                     gmake libsodium curl pkg-config openssl
+    if command_exists bun; then
+        pkgin -y install python311 py311-pip smartmontools \
+                         git perl mbuffer lzop pv mozilla-rootcerts \
+                         p5-Config-IniFiles p5-Capture-Tiny \
+                         gmake libsodium curl pkg-config openssl
+    else
+        pkgin -y install python311 py311-pip nodejs smartmontools \
+                         git perl mbuffer lzop pv mozilla-rootcerts \
+                         p5-Config-IniFiles p5-Capture-Tiny \
+                         gmake libsodium curl pkg-config openssl
+    fi
 
     # Create Python symlinks if they don't exist
     if [ ! -f /usr/pkg/bin/python3 ]; then
@@ -275,19 +282,26 @@ PYTHON_PATH=$(command -v "$PYTHON_CMD")
 PYTHON_VERSION=$($PYTHON_CMD -c 'import sys; print(".".join(map(str, sys.version_info[:2])))')
 printf "${GREEN}✓${NC} Python $PYTHON_VERSION found ($PYTHON_CMD)\n"
 
-if ! command_exists node; then
-    printf "${RED}Error: Node.js is not installed${NC}\n"
-    echo "Please install Node.js first"
+if command_exists bun; then
+    JS_PACKAGE_MANAGER="bun"
+    JS_PACKAGE_MANAGER_PATH="$(command -v bun)"
+    JS_PACKAGE_MANAGER_NAME="Bun"
+    printf "${GREEN}✓${NC} Bun $(bun --version) found\n"
+elif ! command_exists node; then
+    printf "${RED}Error: Neither Bun nor Node.js is installed${NC}\n"
+    echo "Please install Bun or Node.js with npm first"
     exit 1
-fi
-printf "${GREEN}✓${NC} Node.js $(node --version) found\n"
-
-if ! command_exists npm; then
+elif ! command_exists npm; then
     printf "${RED}Error: npm is not installed${NC}\n"
-    echo "Please install npm first"
+    echo "Please install npm or Bun first"
     exit 1
+else
+    printf "${GREEN}✓${NC} Node.js $(node --version) found\n"
+    JS_PACKAGE_MANAGER="npm"
+    JS_PACKAGE_MANAGER_PATH="$(command -v npm)"
+    JS_PACKAGE_MANAGER_NAME="Node.js"
+    printf "${GREEN}✓${NC} npm $(npm --version) found\n"
 fi
-printf "${GREEN}✓${NC} npm $(npm --version) found\n"
 
 # Check for Rust (optional - only needed if pre-compiled wheels are unavailable)
 # Try to source cargo env if rustup is installed
@@ -459,7 +473,7 @@ fi
 echo
 
 # Install dependencies
-echo "Installing Python and Node.js dependencies..."
+echo "Installing Python and ${JS_PACKAGE_MANAGER_NAME} dependencies..."
 echo "(This should be quick with pre-compiled wheels...)"
 echo
 
@@ -501,14 +515,18 @@ echo "Installing/upgrading pip in virtual environment..."
 echo "Installing Python dependencies (using pre-compiled wheels)..."
 .venv/bin/pip install --find-links="$WHEELS_DIR" -r requirements.txt >> install_log.txt 2>&1
 
-echo "Installing Node.js dependencies..."
-npm install >> install_log.txt 2>&1
+echo "Installing ${JS_PACKAGE_MANAGER_NAME} dependencies..."
+"$JS_PACKAGE_MANAGER_PATH" install >> install_log.txt 2>&1
 
 echo "Creating static directory structure..."
 mkdir -p static/css
 
 echo "Building static assets..."
-npm run build:css >> install_log.txt 2>&1
+if [ "$JS_PACKAGE_MANAGER" = "bun" ]; then
+    "$JS_PACKAGE_MANAGER_PATH" ./node_modules/postcss-cli/index.js src/styles.css -o static/css/styles.css >> install_log.txt 2>&1
+else
+    "$JS_PACKAGE_MANAGER_PATH" run build:css >> install_log.txt 2>&1
+fi
 
 # Create .env file if it doesn't exist
 if [ ! -f ".env" ]; then
@@ -523,7 +541,7 @@ fi
 
 echo
 printf "${GREEN}✓${NC} Python dependencies installed\n"
-printf "${GREEN}✓${NC} Node.js dependencies installed\n"
+printf "${GREEN}✓${NC} ${JS_PACKAGE_MANAGER_NAME} dependencies installed\n"
 printf "${GREEN}✓${NC} Static assets built\n"
 printf "${GREEN}✓${NC} Configuration file created\n"
 echo

--- a/package-lock.json
+++ b/package-lock.json
@@ -746,9 +746,9 @@
       }
     },
     "node_modules/nanoid": {
-+      "version": "3.3.12",
-+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.12.tgz",
-+      "integrity": "sha512-ZB9RH/39qpq5Vu6Y+NmUaFhQR6pp+M2Xt76XBnEwDaGcVAqhlvxrl3B2bKS5D3NH3QR76v3aSrKaF/Kiy7lEtQ=="
+      "version": "3.3.12",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.12.tgz",
+      "integrity": "sha512-ZB9RH/39qpq5Vu6Y+NmUaFhQR6pp+M2Xt76XBnEwDaGcVAqhlvxrl3B2bKS5D3NH3QR76v3aSrKaF/Kiy7lEtQ==",
       "funding": [
         {
           "type": "github",
@@ -866,9 +866,9 @@
       }
     },
     "node_modules/postcss": {
-+      "version": "8.5.15",
-+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.15.tgz",
-+      "integrity": "sha512-FfR8sjd4em2T6fb3I2MwAJU7HWVMr9zba+enmQeeWFfCbm+UOC/0X4DS8XtpUTMwWMGbjKYP7xjfNekzyGmB3A==",
+      "version": "8.5.15",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.15.tgz",
+      "integrity": "sha512-FfR8sjd4em2T6fb3I2MwAJU7HWVMr9zba+enmQeeWFfCbm+UOC/0X4DS8XtpUTMwWMGbjKYP7xjfNekzyGmB3A==",
       "funding": [
         {
           "type": "opencollective",

--- a/services/smart_monitoring.py
+++ b/services/smart_monitoring.py
@@ -125,31 +125,37 @@ class SMARTMonitoringService:
             List of disk information dictionaries
         """
         try:
-            # Try to get list from smartctl --scan
             smartctl = self._get_smartctl_cmd()
-            result = run_privileged_command([smartctl, '--scan'])
-            
             disks = []
-            for line in result.stdout.strip().split('\n'):
-                if not line:
+            result = run_privileged_command([smartctl, '--scan', '-j'], check=False)
+            try:
+                devices = json.loads(result.stdout).get('devices', [])
+            except json.JSONDecodeError:
+                devices = []
+
+            if not devices:
+                result = run_privileged_command([smartctl, '--scan'])
+                devices = [
+                    {'name': line.split()[0]}
+                    for line in result.stdout.strip().split('\n')
+                    if line
+                ]
+
+            for device in devices:
+                disk_path = device.get('name')
+                if not disk_path:
                     continue
-                
-                parts = line.split()
-                if len(parts) >= 1:
-                    disk_path = parts[0]
-                    disk_name = disk_path.split('/')[-1]
-                    
-                    # Get basic info for each disk
-                    info = self._get_basic_disk_info(disk_path)
-                    disks.append({
-                        'path': disk_path,
-                        'name': disk_name,
-                        'model': info.get('model', 'Unknown'),
-                        'serial': info.get('serial', 'Unknown'),
-                        'smart_enabled': info.get('smart_enabled', False),
-                        'smart_available': info.get('smart_available', False)
-                    })
-            
+
+                info = self._get_basic_disk_info(disk_path)
+                disks.append({
+                    'path': disk_path,
+                    'name': disk_path.split('/')[-1],
+                    'model': info.get('model', 'Unknown'),
+                    'serial': info.get('serial', 'Unknown'),
+                    'smart_enabled': info.get('smart_enabled', False),
+                    'smart_available': info.get('smart_available', False)
+                })
+
             return disks
             
         except subprocess.CalledProcessError as e:
@@ -200,17 +206,21 @@ class SMARTMonitoringService:
         try:
             smartctl = self._get_smartctl_cmd()
             result = run_privileged_command(
-                [smartctl, '-H', disk],
+                [smartctl, '-H', '-j', disk],
                 check=False
             )
-            
-            health = 'UNKNOWN'
-            for line in result.stdout.split('\n'):
-                if 'SMART overall-health' in line or 'SMART Health Status' in line:
-                    if 'PASSED' in line:
-                        health = 'PASSED'
-                    elif 'FAILED' in line:
-                        health = 'FAILED'
+
+            try:
+                passed = json.loads(result.stdout).get('smart_status', {}).get('passed')
+            except json.JSONDecodeError:
+                passed = None
+
+            if passed is True:
+                health = 'PASSED'
+            elif passed is False:
+                health = 'FAILED'
+            else:
+                health = self._extract_health(result.stdout)
             
             return {
                 'disk': disk,
@@ -254,13 +264,7 @@ class SMARTMonitoringService:
             Disk information dictionary
         """
         try:
-            smartctl = self._get_smartctl_cmd()
-            result = run_privileged_command(
-                [smartctl, '-i', disk],
-                check=False
-            )
-            
-            return self._parse_device_info(result.stdout)
+            return self._get_basic_disk_info(disk)
             
         except subprocess.CalledProcessError as e:
             raise Exception(f"Failed to get disk info: {e.stderr}")
@@ -646,10 +650,17 @@ class SMARTMonitoringService:
         try:
             smartctl = self._get_smartctl_cmd()
             result = run_privileged_command(
-                [smartctl, '-i', disk],
+                [smartctl, '-i', '-j', disk],
                 check=False
             )
-            return self._parse_device_info(result.stdout)
+            try:
+                return self._parse_device_info_json(json.loads(result.stdout))
+            except json.JSONDecodeError:
+                result = run_privileged_command(
+                    [smartctl, '-i', disk],
+                    check=False
+                )
+                return self._parse_device_info(result.stdout)
         except:
             return {}
     
@@ -657,11 +668,44 @@ class SMARTMonitoringService:
         """Extract health status from smartctl output"""
         for line in output.split('\n'):
             if 'SMART overall-health' in line or 'SMART Health Status' in line:
-                if 'PASSED' in line:
+                value = line.split(':', 1)[-1].strip().upper()
+                if 'PASSED' in value or value in {'OK', 'GOOD'}:
                     return 'PASSED'
-                elif 'FAILED' in line:
+                elif 'FAILED' in value:
                     return 'FAILED'
         return 'UNKNOWN'
+
+    def _parse_device_info_json(self, data: Dict[str, Any]) -> Dict[str, Any]:
+        """Parse device information from smartctl JSON output."""
+        info: Dict[str, Any] = {}
+
+        model = data.get('model_name')
+        if not model:
+            model = ' '.join(
+                value for value in (
+                    data.get('scsi_vendor'),
+                    data.get('scsi_product'),
+                ) if value
+            )
+        if model:
+            info['model'] = model
+
+        if data.get('serial_number'):
+            info['serial'] = data['serial_number']
+        if data.get('firmware_version') or data.get('scsi_revision'):
+            info['firmware'] = data.get('firmware_version') or data['scsi_revision']
+
+        capacity = data.get('user_capacity', {}).get('bytes')
+        if capacity is not None:
+            info['capacity'] = f'{capacity:,} bytes'
+
+        smart_support = data.get('smart_support', {})
+        if 'available' in smart_support:
+            info['smart_available'] = smart_support['available']
+        if 'enabled' in smart_support:
+            info['smart_enabled'] = smart_support['enabled']
+
+        return info
     
     def _parse_smart_attributes(self, output: str) -> List[Dict[str, Any]]:
         """Parse SMART attributes table"""
@@ -695,6 +739,8 @@ class SMARTMonitoringService:
     def _parse_device_info(self, output: str) -> Dict[str, Any]:
         """Parse device information from smartctl output"""
         info = {}
+        vendor = None
+        product = None
         
         for line in output.split('\n'):
             if ':' in line:
@@ -704,6 +750,10 @@ class SMARTMonitoringService:
                 
                 if 'model' in key:
                     info['model'] = value
+                elif key == 'vendor':
+                    vendor = value
+                elif key == 'product':
+                    product = value
                 elif 'serial' in key:
                     info['serial'] = value
                 elif 'capacity' in key or 'size' in key:
@@ -715,6 +765,9 @@ class SMARTMonitoringService:
                         info['smart_available'] = True
                     elif 'Enabled' in value:
                         info['smart_enabled'] = True
+
+        if 'model' not in info and product:
+            info['model'] = ' '.join(value for value in (vendor, product) if value)
 
         return info
     

--- a/services/smart_monitoring.py
+++ b/services/smart_monitoring.py
@@ -424,6 +424,11 @@ class SMARTMonitoringService:
                     if len(parts) >= 10:
                         temp = parts[9]
                         break
+                if 'Current Drive Temperature:' in line:
+                    match = re.search(r'\d+', line.split(':', 1)[1])
+                    if match:
+                        temp = match.group()
+                        break
             
             return {
                 'disk': disk,
@@ -731,9 +736,64 @@ class SMARTMonitoringService:
                         'type': parts[6],
                         'updated': parts[7],
                         'when_failed': parts[8],
-                        'raw_value': ' '.join(parts[9:])
+                        'raw_value': ' '.join(parts[9:]),
+                        'source': 'ata'
                     })
-        
+
+        if attributes:
+            return attributes
+
+        return self._parse_scsi_smart_data(output)
+
+    def _parse_scsi_smart_data(self, output: str) -> List[Dict[str, Any]]:
+        """Parse the SMART values reported by SCSI/SAS drives."""
+        field_names = (
+            'Accumulated load-unload cycles',
+            'Accumulated power on time, hours:minutes',
+            'Accumulated start-stop cycles',
+            'Current Drive Temperature',
+            'Drive Trip Temperature',
+            'Elements in grown defect list',
+            'Manufactured in week',
+            'Specified cycle count over device lifetime',
+            'Specified load-unload count over device lifetime',
+        )
+        attributes = []
+
+        for line in output.split('\n'):
+            line = line.strip()
+            name = None
+            value = None
+            for field_name in field_names:
+                if line.startswith(f'{field_name}:'):
+                    name = field_name
+                    value = line[len(field_name) + 1:].strip()
+                    break
+                if field_name in {
+                    'Accumulated power on time, hours:minutes',
+                    'Manufactured in week',
+                } and line.startswith(f'{field_name} '):
+                    name = field_name
+                    value = line[len(field_name):].strip()
+                    break
+
+            if not name or not value:
+                continue
+
+            attributes.append({
+                'id': 'SCSI',
+                'name': name,
+                'flag': '-',
+                'value': value,
+                'worst': '-',
+                'thresh': '-',
+                'type': 'SCSI',
+                'updated': 'N/A',
+                'when_failed': '-',
+                'raw_value': value,
+                'source': 'scsi',
+            })
+
         return attributes
     
     def _parse_device_info(self, output: str) -> Dict[str, Any]:

--- a/setup_dev_freebsd.sh
+++ b/setup_dev_freebsd.sh
@@ -90,23 +90,26 @@ fi
 
 printf "${GREEN}✓${NC} Python $PYTHON_VERSION found ($PYTHON_CMD)\n"
 
-if ! command_exists node; then
-    printf "${RED}Error: Node.js is not installed${NC}\n"
-    echo "Please install Node.js first:"
-    echo "  pkg install node npm"
+if command_exists bun; then
+    JS_PACKAGE_MANAGER="bun"
+    JS_PACKAGE_MANAGER_PATH="$(command -v bun)"
+    JS_PACKAGE_MANAGER_NAME="Bun"
+    printf "${GREEN}✓${NC} Bun $(bun --version) found\n"
+elif ! command_exists node; then
+    printf "${RED}Error: Neither Bun nor Node.js is installed${NC}\n"
+    echo "Please install Bun or Node.js with npm first"
     exit 1
-fi
-
-printf "${GREEN}✓${NC} Node.js $(node --version) found\n"
-
-if ! command_exists npm; then
+elif ! command_exists npm; then
     printf "${RED}Error: npm is not installed${NC}\n"
-    echo "Please install npm first:"
-    echo "  pkg install npm"
+    echo "Please install npm or Bun first"
     exit 1
+else
+    printf "${GREEN}✓${NC} Node.js $(node --version) found\n"
+    JS_PACKAGE_MANAGER="npm"
+    JS_PACKAGE_MANAGER_PATH="$(command -v npm)"
+    JS_PACKAGE_MANAGER_NAME="Node.js"
+    printf "${GREEN}✓${NC} npm $(npm --version) found\n"
 fi
-
-printf "${GREEN}✓${NC} npm $(npm --version) found\n"
 
 # Check for ZFS (should be built-in on FreeBSD)
 if ! command_exists zpool || ! command_exists zfs; then
@@ -172,15 +175,18 @@ echo "(This may take a few minutes on first run...)"
 pip install -r requirements.txt > /dev/null 2>&1
 printf "${GREEN}✓${NC} Python dependencies installed\n"
 
-# Install Node.js dependencies
-echo "Installing Node.js dependencies..."
-npm install > /dev/null 2>&1
-printf "${GREEN}✓${NC} Node.js dependencies installed\n"
+echo "Installing ${JS_PACKAGE_MANAGER_NAME} dependencies..."
+"$JS_PACKAGE_MANAGER_PATH" install > /dev/null 2>&1
+printf "${GREEN}✓${NC} ${JS_PACKAGE_MANAGER_NAME} dependencies installed\n"
 
 # Build static assets
 echo "Building static assets..."
 mkdir -p static/css
-npm run build:css > /dev/null 2>&1
+if [ "$JS_PACKAGE_MANAGER" = "bun" ]; then
+    "$JS_PACKAGE_MANAGER_PATH" ./node_modules/postcss-cli/index.js src/styles.css -o static/css/styles.css > /dev/null 2>&1
+else
+    "$JS_PACKAGE_MANAGER_PATH" run build:css > /dev/null 2>&1
+fi
 printf "${GREEN}✓${NC} Static assets built\n"
 
 # Copy theme CSS files if available

--- a/setup_dev_linux.sh
+++ b/setup_dev_linux.sh
@@ -82,20 +82,26 @@ fi
 
 echo -e "${GREEN}✓${NC} Python $PYTHON_VERSION found ($PYTHON_CMD)"
 
-if ! command_exists node; then
-    echo -e "${RED}Error: Node.js is not installed${NC}"
-    echo "Please install Node.js v20+ and try again"
+if command_exists bun; then
+    JS_PACKAGE_MANAGER="bun"
+    JS_PACKAGE_MANAGER_PATH="$(command -v bun)"
+    JS_PACKAGE_MANAGER_NAME="Bun"
+    echo -e "${GREEN}✓${NC} Bun $(bun --version) found"
+elif ! command_exists node; then
+    echo -e "${RED}Error: Neither Bun nor Node.js is installed${NC}"
+    echo "Please install Bun or Node.js v20+ with npm and try again"
     exit 1
-fi
-
-echo -e "${GREEN}✓${NC} Node.js $(node --version) found"
-
-if ! command_exists npm; then
+elif ! command_exists npm; then
     echo -e "${RED}Error: npm is not installed${NC}"
+    echo "Please install npm or Bun and try again"
     exit 1
+else
+    echo -e "${GREEN}✓${NC} Node.js $(node --version) found"
+    JS_PACKAGE_MANAGER="npm"
+    JS_PACKAGE_MANAGER_PATH="$(command -v npm)"
+    JS_PACKAGE_MANAGER_NAME="Node.js"
+    echo -e "${GREEN}✓${NC} npm $(npm --version) found"
 fi
-
-echo -e "${GREEN}✓${NC} npm $(npm --version) found"
 
 # Check for ZFS
 if ! command_exists zpool || ! command_exists zfs; then
@@ -136,15 +142,18 @@ echo "Installing Python dependencies..."
 pip install -r requirements.txt > /dev/null 2>&1
 echo -e "${GREEN}✓${NC} Python dependencies installed"
 
-# Install Node.js dependencies
-echo "Installing Node.js dependencies..."
-npm install > /dev/null 2>&1
-echo -e "${GREEN}✓${NC} Node.js dependencies installed"
+echo "Installing ${JS_PACKAGE_MANAGER_NAME} dependencies..."
+"$JS_PACKAGE_MANAGER_PATH" install > /dev/null 2>&1
+echo -e "${GREEN}✓${NC} ${JS_PACKAGE_MANAGER_NAME} dependencies installed"
 
 # Build static assets
 echo "Building static assets..."
 mkdir -p static/css
-npm run build:css > /dev/null 2>&1
+if [ "$JS_PACKAGE_MANAGER" = "bun" ]; then
+    "$JS_PACKAGE_MANAGER_PATH" ./node_modules/postcss-cli/index.js src/styles.css -o static/css/styles.css > /dev/null 2>&1
+else
+    "$JS_PACKAGE_MANAGER_PATH" run build:css > /dev/null 2>&1
+fi
 echo -e "${GREEN}✓${NC} Static assets built"
 
 # Copy theme CSS files if available

--- a/templates/utils/smart/attributes.jinja
+++ b/templates/utils/smart/attributes.jinja
@@ -1,6 +1,7 @@
 {% extends "layout.jinja" %}
 
 {% block content %}
+{% set scsi_attributes = attributes and attributes[0].source == 'scsi' %}
 <div class="container mx-auto px-4 py-8">
     <!-- Breadcrumb Navigation -->
     <nav class="text-sm mb-6 text-text-tertiary">
@@ -57,6 +58,12 @@
         <div class="overflow-x-auto">
             <table class="min-w-full">
                 <thead class="bg-bg-elevated-2 text-text-secondary">
+                    {% if scsi_attributes %}
+                    <tr>
+                        <th class="px-4 py-3 text-left text-xs font-medium uppercase tracking-wider">SCSI/SAS SMART Metric</th>
+                        <th class="px-4 py-3 text-left text-xs font-medium uppercase tracking-wider">Value</th>
+                    </tr>
+                    {% else %}
                     <tr>
                         <th class="px-4 py-3 text-left text-xs font-medium uppercase tracking-wider">ID</th>
                         <th class="px-4 py-3 text-left text-xs font-medium uppercase tracking-wider">Attribute Name</th>
@@ -68,9 +75,16 @@
                         <th class="px-4 py-3 text-left text-xs font-medium uppercase tracking-wider">When Failed</th>
                         <th class="px-4 py-3 text-left text-xs font-medium uppercase tracking-wider">Raw Value</th>
                     </tr>
+                    {% endif %}
                 </thead>
                 <tbody class="bg-bg-elevated divide-y divide-border-subtle">
                     {% for attr in attributes %}
+                    {% if scsi_attributes %}
+                    <tr class="hover:bg-bg-elevated-2 transition-colors">
+                        <td class="px-4 py-3 text-text-primary font-semibold">{{ attr.name }}</td>
+                        <td class="px-4 py-3 text-text-secondary font-mono">{{ attr.raw_value }}</td>
+                    </tr>
+                    {% else %}
                     <tr class="hover:bg-bg-elevated-2 transition-colors">
                         <td class="px-4 py-3 whitespace-nowrap text-text-secondary font-mono">{{ attr.id }}</td>
                         <td class="px-4 py-3 text-text-primary font-semibold">{{ attr.name }}</td>
@@ -92,6 +106,7 @@
                         </td>
                         <td class="px-4 py-3 text-text-secondary font-mono text-sm">{{ attr.raw_value }}</td>
                     </tr>
+                    {% endif %}
                     {% endfor %}
                 </tbody>
             </table>
@@ -100,7 +115,7 @@
 
     <!-- Attribute Count -->
     <div class="mt-4 text-text-tertiary text-sm">
-        <p>Total Attributes: {{ attributes|length }}</p>
+        <p>Total {{ 'SCSI/SAS SMART Metrics' if scsi_attributes else 'Attributes' }}: {{ attributes|length }}</p>
     </div>
     {% else %}
     <!-- No Attributes Found -->
@@ -119,7 +134,10 @@
     <div class="mt-6 bg-info-900/30 border-2 border-info-500/50 text-info-400 px-4 py-3 rounded">
         <strong><svg class="w-5 h-5 inline" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                         <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M13 16h-1v-4h-1m1-4h.01M21 12a9 9 0 11-18 0 9 9 0 0118 0z"/>
-                    </svg> About SMART Attributes:</strong>
+                    </svg> About {{ 'SCSI/SAS SMART Data' if scsi_attributes else 'SMART Attributes' }}:</strong>
+        {% if scsi_attributes %}
+        <p class="mt-2 text-sm">SCSI/SAS disks do not expose the ATA SMART attribute table. These values are reported through the drive's SCSI SMART/Log Sense data.</p>
+        {% else %}
         <ul class="mt-2 text-sm list-disc list-inside space-y-1">
             <li><strong>Value:</strong> Normalized value</li>
             <li><strong>Worst:</strong> Worst value ever recorded</li>
@@ -128,6 +146,7 @@
             <li><strong>Old_age:</strong> Indicates normal wear and tear</li>
             <li><strong>Raw Value:</strong> Actual measured value from the drive</li>
         </ul>
+        {% endif %}
     </div>
 </div>
 {% endblock %}

--- a/update_freebsd.sh
+++ b/update_freebsd.sh
@@ -62,6 +62,27 @@ if [ ! -f "/usr/local/etc/rc.d/webzfs" ]; then
     exit 1
 fi
 
+if command -v bun >/dev/null 2>&1; then
+    JS_PACKAGE_MANAGER="bun"
+    JS_PACKAGE_MANAGER_PATH="$(command -v bun)"
+    JS_PACKAGE_MANAGER_NAME="Bun"
+    printf "${GREEN}✓${NC} Bun $(bun --version) found\n"
+elif ! command -v node >/dev/null 2>&1; then
+    printf "${RED}Error: Neither Bun nor Node.js is installed${NC}\n"
+    echo "Please install Bun or Node.js with npm first"
+    exit 1
+elif ! command -v npm >/dev/null 2>&1; then
+    printf "${RED}Error: npm is not installed${NC}\n"
+    echo "Please install npm or Bun first"
+    exit 1
+else
+    printf "${GREEN}✓${NC} Node.js $(node --version) found\n"
+    JS_PACKAGE_MANAGER="npm"
+    JS_PACKAGE_MANAGER_PATH="$(command -v npm)"
+    JS_PACKAGE_MANAGER_NAME="Node.js"
+    printf "${GREEN}✓${NC} npm $(npm --version) found\n"
+fi
+
 # Check if service is running
 SERVICE_WAS_RUNNING=false
 if service webzfs status >/dev/null 2>&1; then
@@ -122,7 +143,7 @@ fi
 echo
 
 # Update dependencies
-echo "Updating Python and Node.js dependencies..."
+echo "Updating Python and ${JS_PACKAGE_MANAGER_NAME} dependencies..."
 echo "(This may take a few minutes...)"
 echo
 
@@ -171,15 +192,19 @@ if ! .venv/bin/pip install $FIND_LINKS_FLAG -r requirements.txt >> update_log.tx
     exit 1
 fi
 
-echo "Updating Node.js dependencies..."
-npm install >> update_log.txt 2>&1
+echo "Updating ${JS_PACKAGE_MANAGER_NAME} dependencies..."
+"$JS_PACKAGE_MANAGER_PATH" install >> update_log.txt 2>&1
 
 echo "Rebuilding static assets..."
-npm run build:css >> update_log.txt 2>&1
+if [ "$JS_PACKAGE_MANAGER" = "bun" ]; then
+    "$JS_PACKAGE_MANAGER_PATH" ./node_modules/postcss-cli/index.js src/styles.css -o static/css/styles.css >> update_log.txt 2>&1
+else
+    "$JS_PACKAGE_MANAGER_PATH" run build:css >> update_log.txt 2>&1
+fi
 
 echo
 printf "${GREEN}✓${NC} Python dependencies updated\n"
-printf "${GREEN}✓${NC} Node.js dependencies updated\n"
+printf "${GREEN}✓${NC} ${JS_PACKAGE_MANAGER_NAME} dependencies updated\n"
 printf "${GREEN}✓${NC} Static assets rebuilt\n"
 echo
 

--- a/update_linux.sh
+++ b/update_linux.sh
@@ -63,6 +63,39 @@ if ! id "$WEBZFS_USER" &>/dev/null; then
     exit 1
 fi
 
+if [ -x "${INSTALL_DIR}/.bun/bin/bun" ]; then
+    JS_PACKAGE_MANAGER="bun"
+    JS_PACKAGE_MANAGER_PATH="${INSTALL_DIR}/.bun/bin/bun"
+    JS_PACKAGE_MANAGER_NAME="Bun"
+    echo -e "${GREEN}✓${NC} Bun $($JS_PACKAGE_MANAGER_PATH --version) found"
+elif command -v bun >/dev/null 2>&1; then
+    JS_PACKAGE_MANAGER="bun"
+    JS_PACKAGE_MANAGER_PATH="$(command -v bun)"
+    JS_PACKAGE_MANAGER_NAME="Bun"
+    echo -e "${GREEN}✓${NC} Bun $(bun --version) found"
+elif ! command -v node >/dev/null 2>&1; then
+    echo -e "${RED}Error: Neither Bun nor Node.js is installed${NC}"
+    echo "Please install Bun or Node.js v20+ with npm and try again"
+    exit 1
+elif ! command -v npm >/dev/null 2>&1; then
+    echo -e "${RED}Error: npm is not installed${NC}"
+    echo "Please install npm or Bun and try again"
+    exit 1
+else
+    echo -e "${GREEN}✓${NC} Node.js $(node --version) found"
+    JS_PACKAGE_MANAGER="npm"
+    JS_PACKAGE_MANAGER_PATH="$(command -v npm)"
+    JS_PACKAGE_MANAGER_NAME="Node.js"
+    echo -e "${GREEN}✓${NC} npm $(npm --version) found"
+fi
+
+if [ "$JS_PACKAGE_MANAGER" = "bun" ] && [ "$JS_PACKAGE_MANAGER_PATH" != "${INSTALL_DIR}/.bun/bin/bun" ]; then
+    BUN_DEPLOY_PATH="${INSTALL_DIR}/.bun/bin/bun"
+    mkdir -p "$(dirname "$BUN_DEPLOY_PATH")"
+    install -m 0755 "$JS_PACKAGE_MANAGER_PATH" "$BUN_DEPLOY_PATH"
+    JS_PACKAGE_MANAGER_PATH="$BUN_DEPLOY_PATH"
+fi
+
 # Check if service is running
 SERVICE_WAS_RUNNING=false
 if systemctl is-active --quiet webzfs 2>/dev/null; then
@@ -162,7 +195,7 @@ echo
 
 # Create a temporary update script that runs as the webzfs user
 TEMP_UPDATE_SCRIPT="${INSTALL_DIR}/_update_deps.sh"
-echo "Updating Python and Node.js dependencies as $WEBZFS_USER..."
+echo "Updating Python and ${JS_PACKAGE_MANAGER_NAME} dependencies as $WEBZFS_USER..."
 echo "(This may take a few minutes...)"
 echo
 
@@ -176,17 +209,25 @@ export HOME="/opt/webzfs"
 
 cd /opt/webzfs
 
+JS_PACKAGE_MANAGER="$JS_PACKAGE_MANAGER_PATH"
+JS_PACKAGE_MANAGER_TYPE="$JS_PACKAGE_MANAGER"
+JS_PACKAGE_MANAGER_NAME="$JS_PACKAGE_MANAGER_NAME"
+
 echo "Upgrading pip in virtual environment..."
 .venv/bin/python3 -m pip install --upgrade pip > update_log.txt 2>&1
 
 echo "Updating Python dependencies..."
 .venv/bin/pip install -r requirements.txt >> update_log.txt 2>&1
 
-echo "Updating Node.js dependencies..."
-npm install >> update_log.txt 2>&1
+echo "Updating \$JS_PACKAGE_MANAGER_NAME dependencies..."
+"\$JS_PACKAGE_MANAGER" install >> update_log.txt 2>&1
 
 echo "Rebuilding static assets..."
-npm run build:css >> update_log.txt 2>&1
+if [ "\$JS_PACKAGE_MANAGER_TYPE" = "bun" ]; then
+    "\$JS_PACKAGE_MANAGER" ./node_modules/postcss-cli/index.js src/styles.css -o static/css/styles.css >> update_log.txt 2>&1
+else
+    "\$JS_PACKAGE_MANAGER" run build:css >> update_log.txt 2>&1
+fi
 
 echo "Dependencies updated successfully!"
 UPDATE_EOF
@@ -207,7 +248,7 @@ rm -f "$TEMP_UPDATE_SCRIPT"
 
 echo
 echo -e "${GREEN}✓${NC} Python dependencies updated"
-echo -e "${GREEN}✓${NC} Node.js dependencies updated"
+echo -e "${GREEN}✓${NC} ${JS_PACKAGE_MANAGER_NAME} dependencies updated"
 echo -e "${GREEN}✓${NC} Static assets rebuilt"
 echo
 

--- a/update_netbsd.sh
+++ b/update_netbsd.sh
@@ -80,6 +80,27 @@ if [ ! -f "/etc/rc.d/webzfs" ]; then
     exit 1
 fi
 
+if command_exists bun; then
+    JS_PACKAGE_MANAGER="bun"
+    JS_PACKAGE_MANAGER_PATH="$(command -v bun)"
+    JS_PACKAGE_MANAGER_NAME="Bun"
+    printf "${GREEN}✓${NC} Bun $(bun --version) found\n"
+elif ! command_exists node; then
+    printf "${RED}Error: Neither Bun nor Node.js is installed${NC}\n"
+    echo "Please install Bun or Node.js with npm first"
+    exit 1
+elif ! command_exists npm; then
+    printf "${RED}Error: npm is not installed${NC}\n"
+    echo "Please install npm or Bun first"
+    exit 1
+else
+    printf "${GREEN}✓${NC} Node.js $(node --version) found\n"
+    JS_PACKAGE_MANAGER="npm"
+    JS_PACKAGE_MANAGER_PATH="$(command -v npm)"
+    JS_PACKAGE_MANAGER_NAME="Node.js"
+    printf "${GREEN}✓${NC} npm $(npm --version) found\n"
+fi
+
 # Check if service is running
 SERVICE_WAS_RUNNING=false
 if /etc/rc.d/webzfs status >/dev/null 2>&1; then
@@ -179,7 +200,7 @@ fi
 echo
 
 # Update dependencies
-echo "Updating Python and Node.js dependencies..."
+echo "Updating Python and ${JS_PACKAGE_MANAGER_NAME} dependencies..."
 echo "(This may take a few minutes...)"
 echo
 
@@ -210,15 +231,19 @@ echo "Upgrading pip in virtual environment..."
 echo "Updating Python dependencies (using pre-compiled wheels)..."
 .venv/bin/pip install --find-links="$WHEELS_DIR" -r requirements.txt >> update_log.txt 2>&1
 
-echo "Updating Node.js dependencies..."
-npm install >> update_log.txt 2>&1
+echo "Updating ${JS_PACKAGE_MANAGER_NAME} dependencies..."
+"$JS_PACKAGE_MANAGER_PATH" install >> update_log.txt 2>&1
 
 echo "Rebuilding static assets..."
-npm run build:css >> update_log.txt 2>&1
+if [ "$JS_PACKAGE_MANAGER" = "bun" ]; then
+    "$JS_PACKAGE_MANAGER_PATH" ./node_modules/postcss-cli/index.js src/styles.css -o static/css/styles.css >> update_log.txt 2>&1
+else
+    "$JS_PACKAGE_MANAGER_PATH" run build:css >> update_log.txt 2>&1
+fi
 
 echo
 printf "${GREEN}✓${NC} Python dependencies updated\n"
-printf "${GREEN}✓${NC} Node.js dependencies updated\n"
+printf "${GREEN}✓${NC} ${JS_PACKAGE_MANAGER_NAME} dependencies updated\n"
 printf "${GREEN}✓${NC} Static assets rebuilt\n"
 echo
 


### PR DESCRIPTION
### Description

Added Bun support to the install, setup, and update scripts across Linux, FreeBSD, and NetBSD. They now prefer Bun when it's present in the environment and fall back to Node/npm otherwise. Also, I fixed some malformed entries in package-lock.json to make Bun working. On the Python side, fixed up the Linux venv setup to verify ensurepip availability and automatically recreate .venv if it's missing pip.

### Testing

I validated the script syntax with `bash -n` and tested to confirm that both `bun install` and `bun run build:css` execute cleanly.

Testing Environment:
freshly installed Ubuntu 26.04
python 3.14
bun 1.3.14

---

Edit:
I also add SAS SMART support. Originally it only showed HDD serial number on my SAS drives.

This update adds support for SAS drives by pulling their health status and model details straight from smartctl's JSON output. Instead of hitting a wall with "No SMART Attributes Found" when ATA attributes aren't present, the system now reads SCSI/SAS SMART metrics and pulls temps directly from the Current Drive Temperature field.